### PR TITLE
Setup CI with GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,11 @@
+name: "Test"
+on:
+  pull_request:
+  push:
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v27
+    - run: nix flake check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: DeterminateSystems/nix-installer-action@main
-    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - uses: cachix/install-nix-action@v25
+    - uses: cachix/cachix-action@v14
+      with:
+        # Don't push builds to Cachix. Use local cache instead.
+        skipPush: true
 
     - name: Cache clojure dependencies
       uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,4 +8,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v27
-    - run: nix flake check
+
+    - name: Clojure tests
+      run: "nix develop --command ./bin/test"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: cachix/install-nix-action@v27
+    - uses: DeterminateSystems/nix-installer-action@main
     - uses: DeterminateSystems/magic-nix-cache-action@main
 
     - name: Clojure tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,5 +10,15 @@ jobs:
     - uses: DeterminateSystems/nix-installer-action@main
     - uses: DeterminateSystems/magic-nix-cache-action@main
 
+    - name: Cache clojure dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.m2/repository
+          ~/.gitlibs
+          ~/.deps.clj
+        key: cljdeps-${{ hashFiles('deps.edn') }}
+        restore-keys: cljdeps-
+
     - name: Clojure tests
       run: "nix develop --command ./bin/test"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,5 +20,13 @@ jobs:
         key: cljdeps-${{ hashFiles('deps.edn') }}
         restore-keys: cljdeps-
 
+    - name: Cache the Nix store
+      uses: actions/cache@v4
+      with:
+        path: |
+          /nix/store
+        key: flake-lock-${{ hashFiles('flake.lock') }}
+        restore-keys: flake-lock-
+
     - name: Clojure tests
       run: "nix develop --command ./bin/test"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,5 @@
 name: "Test"
-on:
-  pull_request:
-  push:
+on: [push]
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,11 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: cachix/install-nix-action@v25
-    - uses: cachix/cachix-action@v14
-      with:
-        # Don't push builds to Cachix. Use local cache instead.
-        skipPush: true
+    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: DeterminateSystems/magic-nix-cache-action@main
 
     - name: Cache clojure dependencies
       uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v27
+    - uses: DeterminateSystems/magic-nix-cache-action@main
 
     - name: Clojure tests
       run: "nix develop --command ./bin/test"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,5 +20,8 @@ jobs:
         key: cljdeps-${{ hashFiles('deps.edn') }}
         restore-keys: cljdeps-
 
+    - name: Fetch nix packages
+      run: "nix develop --command true"
+
     - name: Clojure tests
       run: "nix develop --command ./bin/test"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,13 @@ jobs:
     - uses: cachix/install-nix-action@v25
     - uses: cachix/cachix-action@v14
       with:
-        # Don't push builds to Cachix. Use local cache instead.
+        # This input is unused, but required.
+        name: my-cache
+        # Skip pushing to Cachix. We only care about GitHub's cache.
         skipPush: true
+        # Same as before.
+        skipAddingSubstituter: true
+
 
     - name: Cache clojure dependencies
       uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,5 @@ jobs:
         key: cljdeps-${{ hashFiles('deps.edn') }}
         restore-keys: cljdeps-
 
-    - name: Cache the Nix store
-      uses: actions/cache@v4
-      with:
-        path: |
-          /nix/store
-        key: flake-lock-${{ hashFiles('flake.lock') }}
-        restore-keys: flake-lock-
-
     - name: Clojure tests
       run: "nix develop --command ./bin/test"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,8 @@ jobs:
     - uses: cachix/install-nix-action@v25
     - uses: cachix/cachix-action@v14
       with:
-        # This input is unused, but required.
-        name: my-cache
-        # Skip pushing to Cachix. We only care about GitHub's cache.
+        # Don't push builds to Cachix. Use local cache instead.
         skipPush: true
-        # Same as before.
-        skipAddingSubstituter: true
-
 
     - name: Cache clojure dependencies
       uses: actions/cache@v4

--- a/test/clj/hypertext_db/delete_this_test.clj
+++ b/test/clj/hypertext_db/delete_this_test.clj
@@ -1,0 +1,6 @@
+(ns hypertext-db.delete-this-test
+  (:require [clojure.test :refer [deftest is testing]]))
+
+(deftest on-pourpose-failing-test
+  (testing "This test will fail on purpose just to check that the CI is working"
+    (is (= 5 (+ 2 2)))))

--- a/test/clj/hypertext_db/delete_this_test.clj
+++ b/test/clj/hypertext_db/delete_this_test.clj
@@ -1,6 +1,0 @@
-(ns hypertext-db.delete-this-test
-  (:require [clojure.test :refer [deftest is testing]]))
-
-(deftest on-pourpose-failing-test
-  (testing "This test will fail on purpose just to check that the CI is working"
-    (is (= 5 (+ 2 2)))))

--- a/test/clj/hypertext_db/graph_test.clj
+++ b/test/clj/hypertext_db/graph_test.clj
@@ -337,9 +337,8 @@
 (declare disj-node-succeeds-when-provided-an-altered-version-of-a-node)
 (defspec disj-node-succeeds-when-provided-an-altered-version-of-a-node
   (prop/for-all
-   [node (s/gen ::node/t)
-    node' (s/gen ::node/t)]
+   [node (s/gen ::node/t)]
    (is (let [graph (empty-graph)
-             node' (-> node' (assoc ::vault-file/id (node/id node)) (update ::node/backlinks disj (node/id node)))]
+             node' (fixtures/node {::vault-file/id (node/id node)})]
          (= graph
             (-> graph (graph/conj-node node) (graph/disj-node node')))))))

--- a/test/clj/hypertext_db/graph_test.clj
+++ b/test/clj/hypertext_db/graph_test.clj
@@ -295,9 +295,8 @@
 (declare conj-node-is-able-to-perform-updates)
 (defspec conj-node-is-able-to-perform-updates 10
   (prop/for-all
-   [node   (s/gen ::node/t)
-    node'  (s/gen ::node/t)]
-   (is (let [node' (-> node' (assoc ::vault-file/id (node/id node)) (update ::node/backlinks disj (node/id node)))
+   [node   (s/gen ::node/t)]
+   (is (let [node' (fixtures/node {::vault-file/id (node/id node)})
              graph (empty-graph)]
          (is (= (graph/conj-node graph node')
                 (-> graph (graph/conj-node node) (graph/conj-node node'))))))))

--- a/test/clj/hypertext_db/test/fixtures.clj
+++ b/test/clj/hypertext_db/test/fixtures.clj
@@ -49,7 +49,10 @@
 (defn node
   "Generates a random `::node/t`."
   ([]  (node {}))
-  ([m] (let [node (merge (generate-one ::node/t) m)]
+  ([m] (let [node (merge (generate-one ::node/t) m)
+             id   (node/id node)]
          ; Prevent the case where the random backlinks include an ID provided in
          ; `m`.
-         (update node ::node/backlinks disj (node/id node)))))
+         (-> node
+             (update ::node/links     disj id)
+             (update ::node/backlinks disj id)))))

--- a/test/clj/hypertext_db/test/fixtures.clj
+++ b/test/clj/hypertext_db/test/fixtures.clj
@@ -52,4 +52,4 @@
   ([m] (let [node (merge (generate-one ::node/t) m)]
          ; Prevent the case where the random backlinks include an ID provided in
          ; `m`.
-         (update node ::node/backlinks disj (::vault-file/id node)))))
+         (update node ::node/backlinks disj (node/id node)))))


### PR DESCRIPTION
CLOSES #3 

## Subtasks

- [x] Introduce a failing test to ensure that the CI is able to catch it.
- [x] Add a test step to the CI.
- [x] Add a Nix packages cache step if necessary.
- [x] Add a Clojure cache step if necessary.
- [x] Remove the failing test.

## Work log

### Initial setup

On commit aaf4150, I added a GitHub Actions workflow called "test"

- [x] For some reason, it's running twice. Fix that.

On commit 23efc67bac3e3747c90e943df40d7d523fbf7f0a I introduced a failing test.

On commit aaf4150 I Introduced a test step to the CI.
  -  :heavy_check_mark: It was able to catch the failing step.
  - :warning:  I also noticed that the test step is taking far too long for my taste (~50s vs ~7s on my machine).
    - Take into account that my machine might be faster than a shared CI server.
    - The test step includes:
      - The time that it's taking to fetch the required nix packages.
      - The time that it's taking to fetch the Clojure packages.

- [x] Add the [Magic Nix Cache](https://github.com/DeterminateSystems/magic-nix-cache-action) action by Determinate Systems and see if it improves the time it takes to run the tests.

### Adding a Nix cache step

On commit [c495f48](https://github.com/jpcenteno/hypertext-db/pull/1/commits/c495f4822cef404ea483a4240e94539886f8d7aa) I added the [Magic Nix Cache](https://github.com/DeterminateSystems/magic-nix-cache-action) action by Determinate Systems.

Then, I pushed an empty commit e779b3568ac064919560cb96c25483254b5c46df to see if there was an improvement in the time that it takes to run the "Clojure tests" step. There was no visible improvement.

- [x] Check if switching to the [Determinate Nix Installer](https://github.com/marketplace/actions/the-determinate-nix-installer) GH action solves the problem.

### Switching to the Determinate System's Nix installer action

On commit 2bbc540cd5900ee849c8f59617b02426cc9b904f, I replaced the nix installer action from Cachix with the one from Determinate Systems.

Then, I pushed another empty commit, f78ebac2d89d14f7dd2f24413b25edd9550380ec to test whether the cache was working. The test step is still taking too long.

- [x] Try adding a Clojure cache action.

### Check if removing the failing test solves the issue

Reading the documentation from the generic [Cache](https://github.com/actions/cache) action, I noticed that caches are not saved by default when a previous step fails.

- [x] Remove the failing test to see if this was the culprit.

### Removing the failing test:

On commit 0b878f2b442f9a0161f101daef2c661afd9f14e1, I removed the failing test making the CI pass.

Then, I pushed the empty commit d7945f80370c49b6403f30fae203f8f9fd371f10 to test the cache. I'm noticing that the test step is still taking too long.

### Adding a Clojure cache step

On commit 9d8b460585142cc49e6c31b6499a5a7baac76af3, I added a step to cache Clojure dependencies.

Then, I submitted commit 9844993147fe49e9bedf4b8a900d57aa0341a5b0 to see if there was any improvement.

While both runs took the same time, the _test_ step stopped downloading the Clojure jars, which seems like an improvement.


### Experiment: Cache `/nix/store` using the Cache GitHub action

Reading the [Magic Nix Cache][magic-nix-cache] documentation, I learnt that it does not store any path to GitHub's native cache storage that can be retrieved from the specified Nix cache source. **Hypotheses:** those external requests are slower than using GitHubs cache.

- Work done:
  - On commit 050a131416f I added a cache step for `/nix/store`.
  - Then I pushed another empty commit, 14c951642b913803ebbb327d1b364add928e7f17, to test it.
- Results:
  - Restoring the `/nix/store` cache resulted in a bunch of permission errors.
- Follow ups:
  - [ ] How does the [Magic Nix Cache][magic-nix-cache] action manage to write to that directory?
  - [X]  Add a separate step that fetches the required nix packages to differentiate the time that it's taking to fetch those packages from the time that it's taking to run those tests.
  - [ ] **Experiment:** Try the actions developed by Cachix.

### Experiment: Separating Nix package fetching from testing into two steps

- Work done:
  - Pushed commit f710517719f40 that reverts 050a131416f, to remove the cache step for `/nix/store`.
  - Pushed commit 7af70b1 to split package fetching from testing.
  - Pushed commit 24865ac to fix a broken generator test that I encontered.
- Results:
  - Commit 24865ac fixed the failing tests:
    -  Here is the [run where tests failed](https://github.com/jpcenteno/hypertext-db/actions/runs/9699987297/job/26770306746)
    - Here is the [run where tests succeed](https://github.com/jpcenteno/hypertext-db/actions/runs/9700118846/job/26770756660)
  - By separating fetching from testing (7af70b1), we can see ([job](https://github.com/jpcenteno/hypertext-db/actions/runs/9700118846/job/26770756660)) that:
    - The package fetching step took`21s` to run. **This is the upper bound that can be optimized by tweaking Nix caches**.
    - The test step took `14s` to run.
- Lessons learnt:
  - There is an upper bound of `14s` to optimize by improving Nix caches.
- Follow ups:
  - [ ] Try the [Nix installer][cachix-installer] and [cachix-action][cachix-action] actions by Cachix to see if this improves. Give up if it does not.

### Experiment: Replace Determinate Systems's actions with the Cachix's alternatives

- Goals
  - [ ] Test if I can see a reduction on the time consumed to bootstrap the Nix environment.
- References:
  - [Continuous integration with GitHub Actions][nix-ci-doc].
  - [cachix/install-nix-action][cachix-installer].
  - [cachix/cachix-action][cachix-action].
- Work done:
  - I messed around with setting up cachix.
    - I noticed that it required a Cachix account. I decided that it was not worth
      the trouble
    - I tried to see if I could use it for local caches only, but I wasn't able
      to figure it out.

I concluded that the cache is ok as it is. I want to move on with other stuff.

[cachix-installer]: https://github.com/cachix/install-nix-action
[cachix-action]: https://github.com/cachix/cachix-action
[magic-nix-cache]: https://github.com/DeterminateSystems/magic-nix-cache-action
[nix-ci-doc]: https://nix.dev/tutorials/nixos/continuous-integration-github-actions
