### PR TITLE
Fix bug in the `fixtures/node` helper function

### DIFF
--- a/test/clj/hypertext_db/test/fixtures.clj
+++ b/test/clj/hypertext_db/test/fixtures.clj
@@ -78,7 +78,7 @@
   "Generates a random `::node/t`."
   ([]  (node {}))
   ([m] (let [node (merge (generate-one ::node/t) m)
-             id   (node/id node)]
+             id   (::vault-file/id node)]
          ; Prevent the case where the random backlinks include an ID provided in
          ; `m`.
          (-> node


### PR DESCRIPTION
The function `fixtures/node` was calling `node/id` on the result of merging a randomly-generated valid `::node/t` value with some other user defined values, which may result in a value that does not conform with `::node/t`, thus raising an error when `node/id` is instrumented.

In particular, I was overriding the generated `::vault-file/id` field with another randomly-generated `::vault-file/id` value. This resulted in flaky tests when the new id matched one of the randomly generated ids from the `::node/links` and `::node/backlinks` sets.