### PR TITLE
Implement `graph/add-node-from-vault-file`

### DIFF
--- a/src/clj/hypertext_db/graph.clj
+++ b/src/clj/hypertext_db/graph.clj
@@ -69,6 +69,32 @@
                   every-backlink-has-its-mirroring-link?))
 
 ; ╔════════════════════════════════════════════════════════════════════════╗
+; ║ Observers                                                              ║
+; ╚════════════════════════════════════════════════════════════════════════╝
+
+(s/fdef node-count
+  :args (s/cat :graph ::t)
+  :ret (s/and integer? (partial <= 0)))
+(defn node-count
+  "Returns the number of nodes in the graph"
+  [graph]
+  (-> graph ::nodes count))
+
+(s/fdef contains-node?
+  :args (s/cat :graph ::t :node-id ::vault-file/id)
+  :ret boolean?)
+(defn contains-node?
+  [graph node-id]
+  (contains? (::nodes graph) node-id))
+
+(s/fdef get-node
+  :args (s/cat :graph ::t :id ::vault-file/id)
+  :ret  (s/nilable ::node/t))
+(defn get-node
+  [graph node-id]
+  (get-in graph [::nodes node-id]))
+
+; ╔════════════════════════════════════════════════════════════════════════╗
 ; ║ Constructor                                                            ║
 ; ╚════════════════════════════════════════════════════════════════════════╝
 

--- a/src/clj/hypertext_db/graph.clj
+++ b/src/clj/hypertext_db/graph.clj
@@ -156,7 +156,8 @@
 
 (s/fdef add-node-from-vault-file
   :args (s/cat :graph ::t :vault-file ::vault-file/t)
-  :ret  ::t)
+  :ret  ::t
+  :fn   #(contains-node? (:ret %) (-> % :args :vault-file ::vault-file/id)))
 (defn add-node-from-vault-file
   [graph vault-file]
   (conj-node graph

--- a/src/clj/hypertext_db/graph.clj
+++ b/src/clj/hypertext_db/graph.clj
@@ -153,3 +153,11 @@
         (disj-node node)
         (assoc-in [::nodes id] node)
         (update ::backlinks backlinks/add-from-node node))))
+
+(s/fdef add-node-from-vault-file
+  :args (s/cat :graph ::t :vault-file ::vault-file/t)
+  :ret  ::t)
+(defn add-node-from-vault-file
+  [graph vault-file]
+  (conj-node graph
+             (node/vault-file-> vault-file)))

--- a/src/clj/hypertext_db/graph.clj
+++ b/src/clj/hypertext_db/graph.clj
@@ -157,8 +157,9 @@
 (s/fdef add-node-from-vault-file
   :args (s/cat :graph ::t :vault-file ::vault-file/t)
   :ret  ::t
-  :fn   #(contains-node? (:ret %) (-> % :args :vault-file ::vault-file/id)))
+  :fn   #(let [arg-vault-file (-> % :args :vault-file)
+               ret-node       (-> % :ret (get-node (::vault-file/id arg-vault-file)))]
+           (= (node/vault-file-> arg-vault-file) ret-node)))
 (defn add-node-from-vault-file
   [graph vault-file]
-  (conj-node graph
-             (node/vault-file-> vault-file)))
+  (conj-node graph (node/vault-file-> vault-file)))


### PR DESCRIPTION
CLOSES #5 

This PR adds the ability to add a vault-file to a graph without parsing.

As an aside, I had to implement some necessary `graph/t` observers that I was postponing for future work:
- `node-count`
- `contains-node?`
- `get-node`